### PR TITLE
Fix es6 issue

### DIFF
--- a/Lib/Api.js
+++ b/Lib/Api.js
@@ -1,7 +1,7 @@
-// import axios from 'axios';
-var axios = require("axios")
+import axios from 'axios';
+// var axios = require("axios")
 
-exports.fetchTweets = function() {
+export function fetchTweets() {
 	axios.get('https://safe-headland-90182.herokuapp.com/')
 		.then(function(response) {
 			console.log(response.data);

--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,6 @@ class App extends Component {
           <span>#</span><input type="text" />
         </div>
         <h1>Tweets</h1>
-        // {this.data.map((item)) => ( <div>{item.text}</div> )}
       </div>
     );
   }

--- a/src/Lib/Api.js
+++ b/src/Lib/Api.js
@@ -1,5 +1,4 @@
 import axios from 'axios';
-// var axios = require("axios")
 
 export function fetchTweets() {
 	axios.get('https://safe-headland-90182.herokuapp.com/')


### PR DESCRIPTION
So the issue here was babel was not transpiling the code. This was because babel is only transpiling code in `/src`. I move the `/Lib` under `src` and everything is fine. 

The reason why [babel](https://babeljs.io/) is only working under src is due to [webpack](https://webpack.github.io/)/babel point the entry point (i.e. the source) to src. This is not a convention I have practice in the past, but since this is the convention from Facebook, I recommend following their conventions and placing all new folders and files into the src directory. 

Next session we will run `npm run eject` so we can break down exactly how webpack and babel work.  